### PR TITLE
Read 'Soort' as int in read_sql_query

### DIFF
--- a/dawacotools/io.py
+++ b/dawacotools/io.py
@@ -117,7 +117,7 @@ def get_daw_mps(mpcode=None, partial_match_mpcode=True):
         mpcode_sql_name="MpCode",
     )
 
-    b = pd.read_sql_query(q, engine)
+    b = pd.read_sql_query(q, engine, dtype={"Soort": int})
     b.set_index("MpCode", inplace=True)
 
     get_daw_soort_mp(b)

--- a/dawacotools/io.py
+++ b/dawacotools/io.py
@@ -343,12 +343,11 @@ def get_daw_soort_mp(a, key="Soort"):
         1: "Waarnemingspunt",
         2: "Pompput",
         3: "Infiltratieput",
+        4: "Point of interest",
         5: "Opp.water meetpunt",
         6: "Monsterpunt",
     }
-    for k, v in sd.items():
-        a.loc[a[key] == k, key] = v
-        a.loc[a[key] == str(k), key] = v
+    a[key] = a[key].map(sd)
 
 
 def get_daw_coords_from_mpcode(mpcode=None, partial_match_mpcode=True):


### PR DESCRIPTION
Pass dtype={'Soort': int} to pd.read_sql_query so the 'Soort' column is loaded as an integer. This enforces consistent typing (avoids object/float inference) and prevents downstream issues in functions that expect an int (e.g. get_daw_soort_mp).