### PR TITLE
Use ActiveDirectoryInteractive for DB auth

### DIFF
--- a/dawacotools/io.py
+++ b/dawacotools/io.py
@@ -15,7 +15,7 @@ connection_string = (
     "SERVER=tcp:pwnka-p-we-prd-dawaco-sql.database.windows.net;"
     "PORT=1433;"
     "DATABASE=Dawacoprod;"
-    "Authentication=ActiveDirectoryIntegrated;"
+    "Authentication=ActiveDirectoryInteractive;"
 )
 dbname = "dbo"
 


### PR DESCRIPTION
Update Azure AD authentication method in dawacotools/io.py from ActiveDirectoryIntegrated to ActiveDirectoryInteractive to enable interactive login flows (e.g., MFA or non-domain environments). This allows users to authenticate interactively when Integrated auth is not available.